### PR TITLE
Package debugedit 5.1. Fixes JB#62525

### DIFF
--- a/rpm/0001-find-debuginfo-Pass-j-down-to-dwz.patch
+++ b/rpm/0001-find-debuginfo-Pass-j-down-to-dwz.patch
@@ -1,0 +1,86 @@
+From 5b23e464528ef988cfcd0a87b3ec8db0520db867 Mon Sep 17 00:00:00 2001
+From: Kalev Lember <klember@redhat.com>
+Date: Thu, 19 Jan 2023 17:03:18 +0100
+Subject: [PATCH 1/4] find-debuginfo: Pass -j down to dwz
+
+Now that dwz 0.15 supports parallel jobs, add a way to control it from
+here. find-debuginfo already has a -j parameter so we can just extend it
+and pass the value down to dwz as well.
+
+This should fix building large packages on memory constrained builders,
+such as webkitgtk on s390x in Fedora koji build system, where we can now
+use the -j option to tune down parallelism to avoid running out of
+memory during dwz run.
+
+Add a configure check to make sure the installed dwz supports the
+-j option.
+
+Signed-off-by: Kalev Lember <klember@redhat.com>
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+---
+ Makefile.am               |  3 ++-
+ configure.ac              | 21 +++++++++++++++++++++
+ scripts/find-debuginfo.in |  1 +
+ 3 files changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 2060b96..4a5092d 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -33,7 +33,8 @@ CLEANFILES = $(bin_SCRIPTS)
+ # Some standard substitutions for scripts
+ do_subst = ($(SED) -e 's,[@]PACKAGE[@],$(PACKAGE),g' \
+ 		   -e 's,[@]VERSION[@],$(VERSION),g' \
+-		   -e 's,[@]READELF[@],$(READELF),g')
++		   -e 's,[@]READELF[@],$(READELF),g' \
++		   -e 's,[@]DWZ_J[@],$(DWZ_J),g')
+ 
+ find-debuginfo: $(top_srcdir)/scripts/find-debuginfo.in Makefile
+ 	$(do_subst) < "$(top_srcdir)/scripts/$@.in" > "$@"
+diff --git a/configure.ac b/configure.ac
+index 6a53365..f2d1571 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -47,6 +47,27 @@ AC_CHECK_TOOL([LD], [ld])
+ AC_CHECK_TOOL([READELF], [readelf])
+ AM_MISSING_PROG(HELP2MAN, help2man)
+ 
++# Whether dwz support -j.
++# Make sure to compile something with -g.
++# Run dwz on it with -j1.
++DWZ_J=""
++AC_CHECK_PROG([DWZ], [dwz], [dwz])
++if test "x$DWZ" = "xdwz"; then
++  save_CFLAGS="$CFLAGS"
++  CFLAGS="$save_CFLAGS -g"
++  AC_CACHE_CHECK([whether the dwz support -j], ac_cv_dwz_j, [dnl
++    AC_LINK_IFELSE([AC_LANG_PROGRAM()],[dnl
++      ac_cv_dwz_j=yes; ${DWZ} -j1 conftest$EXEEXT 2>/dev/null || ac_cv_dwz_j=no],
++      AC_MSG_FAILURE([unexpected compile failure]))])
++  if test "x$ac_cv_dwz_j" = "xyes"; then
++    DWZ_J="-j"
++  fi
++  CFLAGS="$save_CFLAGS"
++else
++  AC_MSG_WARN([dwz not installed])
++fi
++AC_SUBST([DWZ_J])
++
+ # Only really an issue on 32bit platforms. Makes sure we'll get large off_t.
+ AC_SYS_LARGEFILE
+ 
+diff --git a/scripts/find-debuginfo.in b/scripts/find-debuginfo.in
+index b07a52f..8090c84 100755
+--- a/scripts/find-debuginfo.in
++++ b/scripts/find-debuginfo.in
+@@ -586,6 +586,7 @@ if $run_dwz \
+     done
+     dwz_multifile_name="${dwz_multifile_name}${dwz_multifile_suffix}"
+     dwz_opts="-h -q -r"
++    [ -n "@DWZ_J@" ] && dwz_opts="${dwz_opts} -j ${n_jobs}"
+     [ ${#dwz_files[@]} -gt 1 ] && [ "$dwz_single_file_mode" = "false" ] \
+       && dwz_opts="${dwz_opts} -m .dwz/${dwz_multifile_name}"
+     mkdir -p "${RPM_BUILD_ROOT}/usr/lib/debug/.dwz"
+-- 
+2.39.1
+

--- a/rpm/0001-openSUSE-finddebuginfo-patch.patch
+++ b/rpm/0001-openSUSE-finddebuginfo-patch.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Greaves <david@dgreaves.com>
+Date: Wed, 17 Apr 2013 20:41:09 +0000
+Subject: [PATCH] openSUSE-finddebuginfo-patch
+
+---
+ scripts/find-debuginfo.in | 49 ++++++++++++++++++++++++++++-----------
+ 1 file changed, 36 insertions(+), 13 deletions(-)
+
+diff --git a/scripts/find-debuginfo.in b/scripts/find-debuginfo.in
+index c192dd8..8d15f85 100755
+--- a/scripts/find-debuginfo.in
++++ b/scripts/find-debuginfo.in
+@@ -434,12 +434,18 @@ trap 'rm -rf "$temp"' EXIT
+ 
+ # Build a list of unstripped ELF files and their hardlinks
+ touch "$temp/primary"
+-find "$RPM_BUILD_ROOT" ! -path "${debugdir}/*.debug" -type f \
+-     		     \( -perm -0100 -or -perm -0010 -or -perm -0001 \) \
+-		     -print | LC_ALL=C sort |
+-file -N -f - | sed -n -e 's/^\(.*\):[ 	]*.*ELF.*, not stripped.*/\1/p' |
+-xargs --no-run-if-empty stat -c '%h %D_%i %n' |
++find "$RPM_BUILD_ROOT" ! -path "${debugdir}/*.debug" -type f \( -perm /111 -or -name "*.so*" -or -name "*.ko" \) ! -name "*.a" -print0 | LC_ALL=C sort -z |
++xargs --no-run-if-empty -0 stat -c '%h %D_%i %n' |
+ while read nlinks inum f; do
++  case $(objdump -h $f 2>/dev/null | grep -o -E '(debug[\.a-z_]*|gnu.version)') in
++    *debuglink*) continue ;;
++    *debug*) ;;
++    *gnu.version*)
++      echo "WARNING: "`echo $f | sed -e "s,^$RPM_BUILD_ROOT/*,/,"`" is already stripped!"
++      continue
++      ;;
++    *) continue ;;
++  esac
+   if [ $nlinks -gt 1 ]; then
+     var=seen_$inum
+     if test -n "${!var}"; then
+@@ -472,6 +478,8 @@ do_file()
+   if [ "$no_recompute_build_id" = "true" ]; then
+     no_recompute="-n"
+   fi
++  mode=$(stat -c %a "$f")
++  chmod +w "$f"
+   id=$(debugedit -b "$debug_base_name" -d "$debug_dest_name" \
+ 			      $no_recompute -i \
+ 			      ${build_id_seed:+--build-id-seed="$build_id_seed"} \
+@@ -503,17 +511,30 @@ do_file()
+   # just has its file names collected and adjusted.
+   case "$dn" in
+   /usr/lib/debug/*)
++    chmod $mode "$f"
+     return ;;
+   esac
+ 
+   mkdir -p "${debugdn}"
+-  if test -w "$f"; then
+-    strip_to_debug "${debugfn}" "$f"
+-  else
+-    chmod u+w "$f"
+-    strip_to_debug "${debugfn}" "$f"
+-    chmod u-w "$f"
+-  fi
++  objcopy --only-keep-debug "$f" "$debugfn" || :
++  (
++    shopt -s extglob
++    strip_option="--strip-all"
++    case "$f" in
++      *.ko)
++	strip_option="--strip-debug" ;;
++      *$STRIP_KEEP_SYMTAB*)
++	if test -n "$STRIP_KEEP_SYMTAB"; then
++	  strip_option="--strip-debug"
++        fi
++        ;;
++    esac
++    if test "$NO_DEBUGINFO_STRIP_DEBUG" = true ; then
++      strip_option=
++    fi
++    objcopy --add-gnu-debuglink="$debugfn" -R .comment -R .GCC.command.line $strip_option "$f"
++    chmod $mode "$f"
++  ) || :
+ 
+   # strip -g implies we have full symtab, don't add mini symtab in that case.
+   # It only makes sense to add a minisymtab for executables and shared
+@@ -689,12 +710,14 @@ if [ -s "$SOURCEFILE" ]; then
+   # and non-standard modes may be inherented from original directories, fixup
+   find "${RPM_BUILD_ROOT}${debug_dest_name}" -type d -print0 |
+   xargs --no-run-if-empty -0 chmod 0755
++  find "${RPM_BUILD_ROOT}${debug_dest_name}" -type f -print0 |
++  xargs --no-run-if-empty -0 chmod a+r
+ fi
+ 
+ if [ -d "${RPM_BUILD_ROOT}/usr/lib" ] || [ -d "${RPM_BUILD_ROOT}/usr/src" ]; then
+   ((nout > 0)) ||
+   test ! -d "${RPM_BUILD_ROOT}/usr/lib" ||
+-  (cd "${RPM_BUILD_ROOT}/usr/lib"; find debug -type d) |
++  (cd "${RPM_BUILD_ROOT}/usr/lib"; test ! -d debug || find debug -type d) |
+   sed 's,^,%dir /usr/lib/,' >> "$LISTFILE"
+ 
+   (cd "${RPM_BUILD_ROOT}/usr"

--- a/rpm/0002-OpenSUSE-finddebuginfo-absolute-links.patch
+++ b/rpm/0002-OpenSUSE-finddebuginfo-absolute-links.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Greaves <david@dgreaves.com>
+Date: Wed, 17 Apr 2013 20:41:09 +0000
+From: Jan Blunck <jblunck@suse.de>
+Subject: Do the symbolic links right in the first place
+
+Since brp-symlink relinks symbolic links to enforce a certain policy we should
+do it right in the first place. So this patch changes find-debuginfo.sh scripts
+behavior to reflect that policy.
+
+Signed-off-by: Jan Blunck <jblunck@suse.de>
+---
+ scripts/find-debuginfo.in | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/find-debuginfo.in b/scripts/find-debuginfo.in
+index 8d15f85..76b0e1e 100755
+--- a/scripts/find-debuginfo.in
++++ b/scripts/find-debuginfo.in
+@@ -413,7 +413,17 @@ debug_link()
+   local l="/usr/lib/debug$2"
+   local t="$1"
+   echo >> "$LINKSFILE" "$l $t"
+-  link_relative "$t" "$l" "$RPM_BUILD_ROOT"
++
++  # this should correspond to what brp-symlink is doing
++  case $t in
++      /usr*)
++     link_relative "$t" "$l" "$RPM_BUILD_ROOT"
++     ;;
++      *)
++     mkdir -p "$(dirname "$RPM_BUILD_ROOT$l")" && \
++         ln -snf "$t" "$RPM_BUILD_ROOT$l"
++     ;;
++  esac
+ }
+ 
+ get_debugfn()

--- a/rpm/0003-OpenSUSE-debugsubpkg.patch
+++ b/rpm/0003-OpenSUSE-debugsubpkg.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Greaves <david@dgreaves.com>
+Date: Wed, 17 Apr 2013 20:41:09 +0000
+Subject: [PATCH] OpenSUSE-debugsubpkg
+
+Create a debuginfo package for each subpackage.
+---
+ scripts/find-debuginfo.in | 29 +++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/scripts/find-debuginfo.in b/scripts/find-debuginfo.in
+index 76b0e1e..4bda5ba 100755
+--- a/scripts/find-debuginfo.in
++++ b/scripts/find-debuginfo.in
+@@ -684,20 +684,25 @@ if $run_dwz \
+   fi
+ fi
+ 
++# We used to make a .debug symlink for each symlink whose target
++# has a .debug file to that file.  This is not necessary because
++# the debuglink section contains only the destination of those links.
++# Creating those links anyway results in debuginfo packages for
++# devel packages just because of the .so symlinks in them.
++
+ # For each symlink whose target has a .debug file,
+ # make a .debug symlink to that file.
+-$quiet || echo "Creating .debug symlinks for symlinks to ELF files" 2>&1
+-find "$RPM_BUILD_ROOT" ! -path "${debugdir}/*" -type l -print |
+-while read f
+-do
+-  t=$(readlink -m "$f").debug
+-  f=${f#$RPM_BUILD_ROOT}
+-  t=${t#$RPM_BUILD_ROOT}
+-  if [ -f "$debugdir$t" ]; then
+-    $verbose && echo "symlinked /usr/lib/debug$t to /usr/lib/debug${f}.debug"
+-    debug_link "/usr/lib/debug$t" "${f}.debug"
+-  fi
+-done
++#find "$RPM_BUILD_ROOT" ! -path "${debugdir}/*" -type l -print |
++#while read f
++#do
++#  t=$(readlink -m "$f").debug
++#  f=${f#$RPM_BUILD_ROOT}
++#  t=${t#$RPM_BUILD_ROOT}
++#  if [ -f "$debugdir$t" ]; then
++#    $verbose && echo "symlinked /usr/lib/debug$t to /usr/lib/debug${f}.debug"
++#    debug_link "/usr/lib/debug$t" "${f}.debug"
++#  fi
++#done
+ 
+ if [ -s "$SOURCEFILE" ]; then
+   # See also debugedit invocation. Directories must match up.

--- a/rpm/0004-Compatibility-with-older-dd.patch
+++ b/rpm/0004-Compatibility-with-older-dd.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Branson <andrew.branson@jollamobile.com>
+Date: Fri, 20 Apr 2018 12:03:11 +0200
+Subject: [PATCH] Compatibility with older dd and bash
+
+---
+ scripts/find-debuginfo.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+ mode change 100755 => 100644 scripts/find-debuginfo.in
+
+diff --git a/scripts/find-debuginfo.in b/scripts/find-debuginfo.in
+old mode 100755
+new mode 100644
+index 4bda5ba..fb3af95
+--- a/scripts/find-debuginfo.in
++++ b/scripts/find-debuginfo.in
+@@ -462,7 +462,7 @@ while read nlinks inum f; do
+       echo "$inum $f" >>"$temp/linked"
+       continue
+     else
+-      read "$var" < <(echo 1)
++      [ "$(( $var = 1 ))" -ne 0 ]
+     fi
+   fi
+   echo "$nlinks $inum $f" >>"$temp/primary"
+@@ -590,7 +590,7 @@ run_job()
+   # can't use read -n <n>, because it reads bytes one by one, allowing for
+   # races
+   while :; do
+-    filenum=$(dd bs=$(( FILENUM_DIGITS + 1 )) count=1 status=none)
++    filenum=$(dd bs=$(( FILENUM_DIGITS + 1 )) count=1 status=noxfer)
+     if test -z "$filenum"; then
+       break
+     fi

--- a/rpm/0005-Remove-manpages.patch
+++ b/rpm/0005-Remove-manpages.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matti Viljanen <matti.viljanen@jolla.com>
+Date: Wed, 26 Feb 2025 18:25:26 +0200
+Subject: [PATCH] Remove manpages
+
+---
+ Makefile.am  | 33 ---------------------------------
+ configure.ac |  1 -
+ 2 files changed, 34 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index c590edf..7dc8b3e 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -49,39 +49,6 @@ sepdebugcrcfix_SOURCES = tools/sepdebugcrcfix.c
+ sepdebugcrcfix_CFLAGS = @LIBELF_CFLAGS@ $(AM_CFLAGS)
+ sepdebugcrcfix_LDADD = @LIBELF_LIBS@
+ 
+-# Manual pages are generated for dist
+-dist_man_MANS = debugedit.1 sepdebugcrcfix.1 find-debuginfo.1
+-
+-# The 'case' ensures the man pages are only generated if the corresponding
+-# source script (the first prerequisite) or configure.ac (for the version)
+-# has been changed.  The executable prerequisite is solely meant to force
+-# these docs to be made only after the executable has been compiled.
+-# This makes sure help2man is not normally necessary (since the generated
+-# man pages are distributed).
+-debugedit.1: tools/debugedit.c configure.ac debugedit$(EXEEXT)
+-	@case '$?' in \
+-	  *$<* | *configure.ac* ) $(HELP2MAN) -N --output=$@ \
+-		--name='debug source path manipulation tool' \
+-		./debugedit$(EXEEXT) ;; \
+-	  * ) : ;; \
+-	esac
+-
+-sepdebugcrcfix.1: tools/sepdebugcrcfix.c configure.ac sepdebugcrcfix$(EXEEXT)
+-	@case '$?' in \
+-	  *$<* | *configure.ac* ) $(HELP2MAN) -N --output=$@ \
+-		--name='fixes CRC for separate .debug files' \
+-		./sepdebugcrcfix$(EXEEXT) ;;\
+-	  * ) : ;; \
+-	esac
+-
+-find-debuginfo.1: $(top_srcdir)/scripts/find-debuginfo.in configure.ac find-debuginfo
+-	@case '$?' in \
+-	  *$<* | *configure.ac* ) $(HELP2MAN) -N --output=$@ \
+-		--name='finds debuginfo and processes it' \
+-		./find-debuginfo ;;\
+-	  * ) : ;; \
+-	esac
+-
+ noinst_HEADERS= tools/ansidecl.h \
+ 		tools/hashtab.h
+ 
+diff --git a/configure.ac b/configure.ac
+index a5a6e28..6840a24 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -45,7 +45,6 @@ m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_C99])
+ AC_PROG_LN_S
+ AC_CHECK_TOOL([LD], [ld])
+ AC_CHECK_TOOL([READELF], [readelf])
+-AM_MISSING_PROG(HELP2MAN, help2man)
+ 
+ # Whether dwz support -j.
+ # Make sure to compile something with -g.

--- a/rpm/0006-PR32760-find-debuginfo-handle-static-libraries.patch
+++ b/rpm/0006-PR32760-find-debuginfo-handle-static-libraries.patch
@@ -1,0 +1,248 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matti Viljanen <matti.viljanen@jolla.com>
+Date: Tue, 5 Aug 2025 17:04:02 +0300
+Subject: [PATCH] PR32760: find-debuginfo: handle static libraries
+
+Formerly, static .a libraries with debuginfo were ignored by
+find-debuginfo.  If unstripped, then the raw build-directory paths in
+them would leak into the downstream package.  New code in
+find-debuginfo looks for archive ".a" files in the build tree, and
+runs debugedit only to enumerate and rewrite source paths.  This
+allows ultimate users of the .a files to link in object files with all
+the debuginfo, except with usable (and debuginfod-resolvable) source
+file paths.
+
+This works by having find-debuginfo find .a files, extracting all
+the .o files one at a time, running debugedit, then repacking the
+files back into the .a.  do_file() delegates to do_ar_file(),
+doing rather less work than for .so/exec files.
+
+New autotest case covers duplicate-member-name functionality,
+including with cruelly whitespace named members.  Defaults off
+& skips testing unless ar support "O" (binutils > v2.31).
+
+Signed-off-by: Frank Ch. Eigler <fche@redhat.com>
+
+PR32760: find-debuginfo: handle static libraries quietly!
+
+A newly done "ar r foo.a" archive-initialization command
+results in an unconditional output to stderr.  Choke it off
+to /dev/null.
+
+Signed-off-by: Frank Ch. Eigler <fche@redhat.com>
+
+(This cherry-pick only updates find-debuginfo.in)
+---
+ scripts/find-debuginfo.in | 142 +++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 139 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/find-debuginfo.in b/scripts/find-debuginfo.in
+index 783f35f..8f8df1f 100644
+--- a/scripts/find-debuginfo.in
++++ b/scripts/find-debuginfo.in
+@@ -5,6 +5,7 @@
+ # for inclusion in package file lists.
+ 
+ # Copyright (C) 2002-2021 rpm and debugedit contributors
++# Copyright (C) 2025 Red Hat Inc.
+ #
+ # This program is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+@@ -28,7 +29,7 @@ automagically generates debug info and file lists
+ Options:
+ [--strict-build-id] [-g] [-r] [-m] [-i] [-n] [-q] [-v]
+ [--keep-section SECTION] [--remove-section SECTION]
+-[--g-libs]
++[--g-libs] [--no-ar-files]
+ [-j N] [--jobs N]
+ [-o debugfiles.list]
+ [-S debugsourcefiles.list]
+@@ -90,6 +91,11 @@ for <FILE> will be named <FILE>-<SUFFIX>.debug.  This makes sure .debug
+ are unique between package version, release and architecture.
+ (Use --unique-debug-suffix "-%{VERSION}-%{RELEASE}.%{_arch}".)
+ 
++If --no-ar-files is given, then static libraries will be ignored.  Otherwise,
++they receive only with source-path rewriting and collection.  They are
++not stripped, since they have no persistent build-ids to accommodate
++eventual reunification.
++
+ If --unique-debug-src-base BASE is given then the source directory
+ will be called /usr/debug/src/<BASE>.  This makes sure the debug source
+ dirs are unique between package version, release and achitecture (Use
+@@ -159,6 +165,13 @@ quiet=false
+ # add more non-error output
+ verbose=false
+ 
++# process static libraries if ar is new enough (binutils 2.31+) to support O
++if [ -n "`ar 2>&1 | grep -F '[O]'`" ]; then
++    process_ar=true
++else
++    process_ar=false
++fi
++
+ BUILDDIR=.
+ out=debugfiles.list
+ srcout=
+@@ -252,6 +265,9 @@ while [ $# -gt 0 ]; do
+     srcout=$2
+     shift
+     ;;
++  --no-ar-files)
++    process_ar=false
++    ;;
+   -q|--quiet)
+     quiet=true
+     verbose=false
+@@ -444,8 +460,19 @@ trap 'rm -rf "$temp"' EXIT
+ 
+ # Build a list of unstripped ELF files and their hardlinks
+ touch "$temp/primary"
+-find "$RPM_BUILD_ROOT" ! -path "${debugdir}/*.debug" -type f \( -perm /111 -or -name "*.so*" -or -name "*.ko" \) ! -name "*.a" -print0 | LC_ALL=C sort -z |
+-xargs --no-run-if-empty -0 stat -c '%h %D_%i %n' |
++(
++    find "$RPM_BUILD_ROOT" ! -path "${debugdir}/*.debug" -type f \( -perm -0100 -or -perm -0010 -or -perm -0001 \) -print |
++        file -N -f - |
++        sed -n -e 's/^\(.*\):[     ]*.*ELF.*, not stripped.*/\1/p';
++
++    # plus static libraries
++    $process_ar && find "$RPM_BUILD_ROOT" -type f -name '*.a' -print |
++            file -N -f - |
++            sed -n -e 's/^\(.*\):[         ]*current ar archive.*/\1/p';
++    true
++) |
++    env LC_ALL=C sort |
++    xargs --no-run-if-empty stat -c '%h %D_%i %n' |
+ while read nlinks inum f; do
+   case $(objdump -h $f 2>/dev/null | grep -o -E '(debug[\.a-z_]*|gnu.version)') in
+     *debuglink*) continue ;;
+@@ -468,14 +495,121 @@ while read nlinks inum f; do
+   echo "$nlinks $inum $f" >>"$temp/primary"
+ done
+ 
++# Handle ELF archives
++do_ar_file()
++{
++  local nlinks="$1" inum="$2" f="$3" id link linked
++  local tmpa="$temp/$inum-output.a"
++  local res=0
++
++  # See also cpio SOURCEFILE copy. Directories must match up.
++  debug_base_name="$RPM_BUILD_DIR"
++  debug_dest_name="/usr/src/debug"
++  if [ ! -z "$unique_debug_src_base" ]; then
++      debug_base_name="$BUILDDIR"
++      debug_dest_name="/usr/src/debug/${unique_debug_src_base}"
++  fi
++
++  $verbose && echo "processing debug info in $f"
++
++  # Extract members from archive, one at a time.  There may be
++  # duplicate names, so we can't just extract the entire archive in
++  # one go (overwriting each other).  Instead, we pick off member
++  # files one-by-one, into synthetic subdirectories, adding processed
++  # versions to a new archive, in order.
++
++  # Create empty output .a; mktemp would create a 0-byte file, which ar rv doesn't like
++  ar r "$tmpa" 2>/dev/null # no members, suppress "ar: creating foo.a" message
++
++  ar tvO "$f" | while read line; do
++      local pattern='^[rwx-]+ [0-9]+/[0-9]+ +([0-9]+) (.................) (.*) (0x[0-9a-f]+)$'
++      if [[ $line =~ $pattern ]]; then
++          local size=${BASH_REMATCH[1]}
++          local date=${BASH_REMATCH[2]}
++          local member=${BASH_REMATCH[3]}
++          local offset
++          (( offset=${BASH_REMATCH[4]} )) # convert from hexadecimal
++          $verbose && echo "considering ${f#$RPM_BUILD_DIR/} ${member} size ${size} at ${offset}"
++          local tmpdir="$temp/$inum-archive-member" # super short lived
++          local member_dn=$(dirname "$member")
++          if [ "$member_dn" = "." ]; then
++              member_dn="" # empty
++          else
++              member_dn="${member_dn}/" # or suffixed with /
++          fi
++          local member_bn=$(basename "$member")
++
++          # (re)create a directory to hold the (pathname-inclusive) member
++          mkdir -p "$tmpdir/$member_dn"
++
++          # extract the file by offset, because extracting it by name
++          # is hard, in case the same name exists multiple times.  A
++          # distinct instance-number would have to be given to ar ("N ###"),
++          # kept on a per-name basis.
++          (cd "$tmpdir"; dd status=none if="$f" of="$member_dn$member_bn" bs=1 skip="$offset" count="$size")
++          if [ $? -ne 0 ]; then
++              res=1
++          fi
++          # preserve timestamp from original file, though debugedit may lose it, PR33096
++          touch -d "$date" "$tmpdir/$member_dn$member_bn"
++
++          if file "$tmpdir/$member_dn$member_bn" |
++                  grep -qE 'ELF.*, not stripped'; then
++              debugedit -b "$debug_base_name" -d "$debug_dest_name" \
++		        -l "$SOURCEFILE" "$tmpdir/$member_dn$member_bn"
++              if [ $? -ne 0 ]; then
++                  res=1
++                  $verbose && echo "failed processing ELF object ${member}"
++              else
++                  $verbose && echo "processed ELF object ${member}"
++              fi
++          else
++              $verbose && echo "skipped ${member}, no debuginfo"
++          fi
++
++          # add the file; qP mode, so strict append, no dupe elimination, path preserved
++          (cd "$tmpdir"; ar qP "$tmpa"  "$member_dn$member_bn")
++
++          # remove the entire temporary directory, in case another
++          # member object comes later with a conflicting name
++          rm -rf  "$tmpdir"
++      else
++          $verbose && echo "skipping archive $f with unparseable contents"
++          res=1
++      fi
++  done
++  if [ $res -eq 0 ]; then
++      # replace original archive with new version
++      ar sP "$tmpa" # ranlib, preserve paths
++      mv "$tmpa" "$f"
++  fi
++  rm -f "$tmpa"
++
++  $verbose && echo found $(tr -dc '\0' < "$SOURCEFILE" | wc -c) source files
++
++  # NB: no need to strip or dwz-compress or gdbindex or
++  # ELFBINSFILE-collect objects / archives.  These operations only
++  # make sense on the final binaries that the static archives are
++  # linked into.
++
++  return $res
++}
++
+ # Strip ELF binaries
+ do_file()
+ {
+   local nlinks=$1 inum=$2 f=$3 id link linked
+ 
++  # reject files already located under /usr/lib/debug, presumably processed
+   get_debugfn "$f"
+   [ -f "${debugfn}" ] && return
+ 
++  local ar_re="^.*\.a$"
++  if [[ $f =~ $ar_re ]]; then # treat as static archive
++      do_ar_file "$1" "$2" "$3"
++      return
++  fi
++
+   $verbose && echo "extracting debug info from $f"
+   # See also cpio SOURCEFILE copy. Directories must match up.
+   debug_base_name="$RPM_BUILD_DIR"
+@@ -499,6 +633,8 @@ do_file()
+     $strict && return 2
+   fi
+ 
++  $verbose && echo found $(tr -dc '\0' < "$SOURCEFILE" | wc -c) source files
++
+   # Add .gdb_index if requested.
+   if $include_gdb_index; then
+     if type gdb-add-index >/dev/null 2>&1; then

--- a/rpm/debugedit.spec
+++ b/rpm/debugedit.spec
@@ -1,0 +1,70 @@
+%define rpmhome /usr/lib/rpm
+
+Name: debugedit
+Version: 5.1
+Release: 1
+Summary: Tools for debuginfo creation
+License: GPLv3+ AND GPLv2+ AND LGPLv2+
+URL: https://github.com/sailfishos/debugedit
+Source0: %{name}-%{version}.tar.bz2
+
+BuildRequires: pkgconfig(libelf)
+BuildRequires: pkgconfig(libdw)
+BuildRequires: xxhash-devel
+BuildRequires: autoconf
+BuildRequires: automake
+
+# The find-debuginfo.sh script has a couple of tools it needs at runtime.
+# For strip_to_debug, eu-strip
+Requires: elfutils
+# For add_minidebug, readelf, awk, nm, sort, comm, objcopy, xz
+Requires: binutils, gawk, coreutils, xz
+# For find and xargs
+Requires: findutils
+# For do_file, gdb_add_index
+# We only need gdb-add-index, so suggest gdb-minimal (full gdb is also ok)
+Requires: /usr/bin/gdb-add-index
+Suggests: gdb-minimal
+# For run_job, sed
+Requires: sed
+# For append_uniq, grep
+Requires: grep
+
+Patch0: 0001-openSUSE-finddebuginfo-patch.patch
+Patch1: 0002-OpenSUSE-finddebuginfo-absolute-links.patch
+Patch2: 0003-OpenSUSE-debugsubpkg.patch
+Patch3: 0004-Compatibility-with-older-dd.patch
+Patch4: 0005-Remove-manpages.patch
+Patch5: 0006-PR32760-find-debuginfo-handle-static-libraries.patch
+
+%description
+The debugedit project provides programs and scripts for creating
+debuginfo and source file distributions, collect build-ids and rewrite
+source paths in DWARF data for debugging, tracing and profiling.
+
+It is based on code originally from the rpm project plus libiberty and
+binutils.  It depends on the elfutils libelf and libdw libraries to
+read and write ELF files, DWARF data and build-ids.
+
+%prep
+%autosetup -p1 -n %{name}-%{version}/upstream
+
+%build
+autoreconf -f -v -i
+%configure
+%make_build
+
+%install
+%make_install
+
+# Temp symlink to make sure things don't break.
+pushd %{buildroot}%{_bindir}
+ln -s find-debuginfo find-debuginfo.sh
+popd
+
+%files
+%license COPYING COPYING3 COPYING.LIB
+%{_bindir}/debugedit
+%{_bindir}/sepdebugcrcfix
+%{_bindir}/find-debuginfo
+%{_bindir}/find-debuginfo.sh


### PR DESCRIPTION
- <del>Split manpages into separate package</del> Don't package manpages
- Add compatibility symlink to find-debuginfo.sh since it's hardcoded in some other places
- Fix `egrep is deprecated` warnings

- <del>Remove some features which would pull in heavy dependencies or would require packaging up more utilities:</del>
  - <del>dwz (not packaged)</del>
  - <del>.gdb_index (would pull in gdb)</del>
<del>We can later package `debugedit-full` which would have all the intended features, if the need arises.</del>

No removed features:
- we have `gdb-add-index` and pulling in full `gdb` is ok
- `find-debuginfo.sh` needs a new flag to use `dwz` -- not worth pathing out if it's unused anyway

Requires https://github.com/sailfishos/xxhash/pull/1